### PR TITLE
Save individual file

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -200,11 +200,11 @@ class App extends Component {
   }
 
   addFileToProject = (fileName, template) => {
-    var currentProject = Object.assign({}, this.state.currentProject)
+    var currentProject = this.state.currentProject
     const app = this
     if (currentProject.files.findIndex((e) => e.name === fileName) !== -1) {
       app.openSnackbar(
-        'Another file with the same name already exists in this project.'
+        'Another file with the same name already exists in this project'
       )
       return
     }
@@ -225,7 +225,7 @@ class App extends Component {
     const app = this
     if (currentProject.files.findIndex((e) => e.name === newFileName) !== -1) {
       app.openSnackbar(
-        'Another file with the same name already exists in this project.'
+        'Another file with the same name already exists in this project'
       )
       return
     }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -200,8 +200,14 @@ class App extends Component {
   }
 
   addFileToProject = (fileName, template) => {
-    var currentProject = this.state.currentProject
+    var currentProject = Object.assign({}, this.state.currentProject)
     const app = this
+    if (currentProject.files.findIndex((e) => e.name === fileName) !== -1) {
+      app.openSnackbar(
+        'Another file with the same name already exists in this project.'
+      )
+      return
+    }
     if (template === '') {
       currentProject.files.push({ name: fileName, text: '', hasChanges: true })
       currentProject.activeFile = fileName
@@ -216,6 +222,13 @@ class App extends Component {
 
   renameFileInProject = (fileName, newFileName) => {
     var currentProject = this.state.currentProject
+    const app = this
+    if (currentProject.files.findIndex((e) => e.name === newFileName) !== -1) {
+      app.openSnackbar(
+        'Another file with the same name already exists in this project.'
+      )
+      return
+    }
     currentProject.files.forEach((element) => {
       if (element.name === fileName) {
         element.name = newFileName
@@ -272,6 +285,17 @@ class App extends Component {
         element.hasChanges = false
       })
       drive.updateProject(currentProject)
+      this.setState({ currentProject: currentProject })
+    } else {
+      this.setState({ signUpDialog: { open: true } })
+    }
+  }
+
+  saveProjectFile = (fileIndex) => {
+    if (this.state.user) {
+      var currentProject = this.state.currentProject
+      currentProject.files[fileIndex].hasChanges = false
+      drive.updateProjectFile(currentProject, fileIndex)
       this.setState({ currentProject: currentProject })
     } else {
       this.setState({ signUpDialog: { open: true } })
@@ -579,6 +603,7 @@ class App extends Component {
                 renameFileRequest={this.openRenameFileDialog}
                 deleteFileRequest={this.removeFileFromProject}
                 setFileActive={this.setFileAsActive}
+                saveProjectFile={this.saveProjectFile}
                 handleEditorChange={this.updateEditorValue}
                 harmonyPanelRef={this.harmonyPanelRef}
                 setHarmonyPanelWidth={this.setHarmonyPanelWidth}

--- a/src/components/HomePage/HomePage.js
+++ b/src/components/HomePage/HomePage.js
@@ -108,6 +108,20 @@ class HomePage extends Component {
     }
   }
 
+  handleKeyDown = (event) => {
+    const { project, saveProjectFile } = this.props
+    const key = event.key || event.keyCode
+    if (
+      (key === 's' || key === 'S' || key === 83) &&
+      (navigator.platform.match('Mac') ? event.metaKey : event.ctrlKey)
+    ) {
+      event.preventDefault()
+      saveProjectFile(
+        project.files.findIndex((e) => e.name === project.activeFile)
+      )
+    }
+  }
+
   render() {
     const {
       classes,
@@ -115,7 +129,6 @@ class HomePage extends Component {
       project,
       addFileRequest,
       setFileActive,
-      saveProjectFile,
       handleEditorChange,
       harmonyPanelRef,
       setHarmonyPanelWidth,
@@ -187,22 +200,7 @@ class HomePage extends Component {
             {project.activeFile && (
               <div
                 className={classes.editorContainer}
-                onKeyDown={(event) => {
-                  const key = event.key || event.keyCode
-                  if (
-                    (key === 's' || key === 'S' || key === 83) &&
-                    (navigator.platform.match('Mac')
-                      ? event.metaKey
-                      : event.ctrlKey)
-                  ) {
-                    event.preventDefault()
-                    saveProjectFile(
-                      project.files.findIndex(
-                        (e) => e.name === project.activeFile
-                      )
-                    )
-                  }
-                }}
+                onKeyDown={this.handleKeyDown}
               >
                 <Editor
                   theme={theme.dark ? 'harmonyThemeDark' : 'harmonyThemeLight'}

--- a/src/components/HomePage/HomePage.js
+++ b/src/components/HomePage/HomePage.js
@@ -58,6 +58,9 @@ const styles = (theme) => ({
   drawerContainer: {
     overflow: 'auto',
   },
+  editorContainer: {
+    height: '100%',
+  },
   content: {
     flexGrow: 1,
     display: 'flex',
@@ -112,6 +115,7 @@ class HomePage extends Component {
       project,
       addFileRequest,
       setFileActive,
+      saveProjectFile,
       handleEditorChange,
       harmonyPanelRef,
       setHarmonyPanelWidth,
@@ -131,23 +135,26 @@ class HomePage extends Component {
           <div className={classes.drawerContainer}>
             <List>
               {project &&
-                project.files.map((text, index, arr) => (
-                  <ListItem
-                    button
-                    id={`${text.name}`}
-                    key={text.name}
-                    selected={text.name === project.activeFile}
-                    onClick={() => setFileActive(text.name)}
-                    onContextMenu={this.displayMenu}
-                  >
-                    <ListItemIcon>
-                      <FileIcon />
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={text.name + (text.hasChanges ? '*' : '')}
-                    />
-                  </ListItem>
-                ))}
+                project.files
+                  .slice()
+                  .sort((a, b) => (a.name > b.name ? 1 : -1))
+                  .map((text, index, arr) => (
+                    <ListItem
+                      button
+                      id={`${text.name}`}
+                      key={text.name}
+                      selected={text.name === project.activeFile}
+                      onClick={() => setFileActive(text.name)}
+                      onContextMenu={this.displayMenu}
+                    >
+                      <ListItemIcon>
+                        <FileIcon />
+                      </ListItemIcon>
+                      <ListItemText
+                        primary={text.name + (text.hasChanges ? '*' : '')}
+                      />
+                    </ListItem>
+                  ))}
               <ListItem button key={'add-file'} onClick={addFileRequest}>
                 <ListItemIcon>
                   <AddIcon />
@@ -178,16 +185,37 @@ class HomePage extends Component {
               description="Sign in to access your files, or start a new one at the top left!"
             />
             {project.activeFile && (
-              <Editor
-                theme={theme.dark ? 'harmonyThemeDark' : 'harmonyThemeLight'}
-                defaultLanguage="harmony"
-                beforeMount={this.handleEditorHarmonyCustomLang.bind(this)}
-                path={project.activeFile}
-                defaultValue={
-                  project.files.find((e) => e.name === project.activeFile).text
-                }
-                onChange={handleEditorChange}
-              />
+              <div
+                className={classes.editorContainer}
+                onKeyDown={(event) => {
+                  const key = event.key || event.keyCode
+                  if (
+                    (key === 's' || key === 'S' || key === 83) &&
+                    (navigator.platform.match('Mac')
+                      ? event.metaKey
+                      : event.ctrlKey)
+                  ) {
+                    event.preventDefault()
+                    saveProjectFile(
+                      project.files.findIndex(
+                        (e) => e.name === project.activeFile
+                      )
+                    )
+                  }
+                }}
+              >
+                <Editor
+                  theme={theme.dark ? 'harmonyThemeDark' : 'harmonyThemeLight'}
+                  defaultLanguage="harmony"
+                  beforeMount={this.handleEditorHarmonyCustomLang.bind(this)}
+                  path={project.activeFile}
+                  defaultValue={
+                    project.files.find((e) => e.name === project.activeFile)
+                      .text
+                  }
+                  onChange={handleEditorChange}
+                />
+              </div>
             )}
           </Box>
         </Box>

--- a/src/components/Router/Router.js
+++ b/src/components/Router/Router.js
@@ -22,6 +22,7 @@ class Router extends Component {
       renameFileRequest,
       deleteFileRequest,
       setFileActive,
+      saveProjectFile,
       handleEditorChange,
       harmonyPanelRef,
       setHarmonyPanelWidth,
@@ -45,6 +46,7 @@ class Router extends Component {
               renameFileRequest={renameFileRequest}
               deleteFileRequest={deleteFileRequest}
               setFileActive={setFileActive}
+              saveProjectFile={saveProjectFile}
               handleEditorChange={handleEditorChange}
               harmonyPanelRef={harmonyPanelRef}
               setHarmonyPanelWidth={setHarmonyPanelWidth}


### PR DESCRIPTION
Added the following features:
1) Ability to save individual files by pressing Ctrl-S (should work on mac wif cmd-S) while in the editor with the file open
2) Prevent new file from having the same name as any existing file, as well as the renaming of existing file to a name of any other existing file
3) Alphabetical sorting of the file explorer (doing it per rerender which is a little inefficient but I thought it will save us some trouble in the long run if we maintain the indexing between the currentProject.files and drive.currentProject.files so we can reference files throughout the app using numeric indices on the files array, even when we are committing to firestore.